### PR TITLE
Update energySystemModel.py

### DIFF
--- a/FINE/energySystemModel.py
+++ b/FINE/energySystemModel.py
@@ -371,9 +371,9 @@ class EnergySystemModel:
         timeSeriesData.index = pd.date_range('2050-01-01 00:30:00', periods=len(self.totalTimeSteps),
                                              freq=(str(self.hoursPerTimeStep) + 'H'), tz='Europe/Berlin')
 
-        # Cluster data with tsam package (the reindex_axis call is here for reproducibility of TimeSeriesAggregation
+        # Cluster data with tsam package (the reindex call is here for reproducibility of TimeSeriesAggregation
         # call)
-        timeSeriesData = timeSeriesData.reindex_axis(sorted(timeSeriesData.columns), axis=1)
+        timeSeriesData = timeSeriesData.reindex(sorted(timeSeriesData.columns), axis=1)
         clusterClass = TimeSeriesAggregation(timeSeries=timeSeriesData, noTypicalPeriods=numberOfTypicalPeriods,
                                              hoursPerPeriod=numberOfTimeStepsPerPeriod*self.hoursPerTimeStep,
                                              clusterMethod=clusterMethod, sortValues=sortValues, weightDict=weightDict,


### PR DESCRIPTION
pandas.DataFrame.reindex_axis is deprecated since version 0.21.0. Used reindex instead.